### PR TITLE
output padding info by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,14 +86,15 @@ function generateBMFont (fontPath, opt, callback) {
   } else reuse = {};
   const outputType = opt.outputType = utils.valueQueue([opt.outputType, reuse.outputType, "xml"]);
   let filename = utils.valueQueue([opt.filename, reuse.filename]);
+  const distanceRange = opt.distanceRange = utils.valueQueue([opt.distanceRange, reuse.distanceRange, 4]);
   const fontSize = opt.fontSize = utils.valueQueue([opt.fontSize, reuse.fontSize, 42]);
   const fontSpacing = opt.fontSpacing = utils.valueQueue([opt.fontSpacing, reuse.fontSpacing, [0, 0]]);
-  const fontPadding = opt.fontPadding = utils.valueQueue([opt.fontPadding, reuse.fontPadding, [0, 0, 0, 0]]);
+  const pad = distanceRange >> 1;
+  const fontPadding = opt.fontPadding = utils.valueQueue([opt.fontPadding, reuse.fontPadding, [pad, pad, pad, pad]]);
   const textureWidth = opt.textureWidth = utils.valueQueue([opt.textureSize || reuse.textureSize, [512, 512]])[0];
   const textureHeight = opt.textureHeight = utils.valueQueue([opt.textureSize || reuse.textureSize, [512, 512]])[1];
   const texturePadding = opt.texturePadding = utils.valueQueue([opt.texturePadding, reuse.texturePadding, 1]);
   const border = opt.border = utils.valueQueue([opt.border, reuse.border, 0]);
-  const distanceRange = opt.distanceRange = utils.valueQueue([opt.distanceRange, reuse.distanceRange, 4]);
   const fieldType = opt.fieldType = utils.valueQueue([opt.fieldType, reuse.fieldType, 'msdf']);
   const roundDecimal = opt.roundDecimal = utils.valueQueue([opt.roundDecimal, reuse.roundDecimal]); // if no roudDecimal option, left null as-is
   const smartSize = opt.smartSize = utils.valueQueue([opt.smartSize, reuse.smartSize, false]);


### PR DESCRIPTION
As discussed in #42, output the padding info in `font.info.padding`.
This lets you, for example, calculate the actual height of the character from `char.height` and `font.common.base`.

![glyph_padding](https://user-images.githubusercontent.com/5791070/64992064-68d50200-d8d3-11e9-968c-0eac15e0d6bc.png)
