### PR TITLE
Fix binary path not working when containing spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -333,7 +333,7 @@ function generateImage (opt, callback) {
     xOffset = utils.roundNumber(xOffset, roundDecimal);
     yOffset = utils.roundNumber(yOffset, roundDecimal);
   }
-  let command = `${binaryPath} ${fieldType} -format text -stdout -size ${width} ${height} -translate ${xOffset} ${yOffset} -pxrange ${distanceRange} -stdin`;
+  let command = `"${binaryPath}" ${fieldType} -format text -stdout -size ${width} ${height} -translate ${xOffset} ${yOffset} -pxrange ${distanceRange} -stdin`;
 
   let subproc = exec(command, (err, stdout, stderr) => {
     if (err) return callback(err);


### PR DESCRIPTION
The command to generate the MSDF glyph does not escape the binary path. This can an exception when the command runs with a space in the path. Surrounding the binary path in quotes fixes this issue.