### PR TITLE
Fix baseline alignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ function generateBMFont (fontPath, opt, callback) {
   }); // Remove duplicate & control chars
 
   const os2 = font.tables.os2;
-  const baseline = os2.sTypoAscender * (fontSize / font.unitsPerEm) + (distanceRange >> 1);
+  const baseline = os2.sTypoAscender * (fontSize / font.unitsPerEm);
 
   const fontface = typeof fontPath === 'string' ? path.basename(fontPath, path.extname(fontPath)) : filename;
 
@@ -381,7 +381,7 @@ function generateImage (opt, callback) {
           width: width,
           height: height,
           xoffset: Math.round(bBox.x1) - pad,
-          yoffset: Math.round(bBox.y1) + pad + baseline,
+          yoffset: Math.round(bBox.y1) - pad + baseline,
           xadvance: glyph.advanceWidth * scale,
           chnl: 15
         }


### PR DESCRIPTION
I've noticed that the `common.base` property does not actually line up with the baseline of the SDF glyphs when they are laid out according to the `yoffset` of each glyph. This seems related to the distance range "pad" that is added to both the baseline and the `yoffset` for each glyph.

**Baseline Adjustment**
I don't think that the baseline itself needs the pad added to it as the distance range itself should not generally affect where the glyph is actually drawn (unless a user opts to render glyphs thicker or thinner than the original font).

**Y-Offset Adjustment**
Just like its done for the `xoffset` already, the pad for `yoffset` is subtracted from the bBox value instead of added.

### Before Change
![before-change](https://github.com/soimy/msdf-bmfont-xml/assets/6070611/b98ba2a7-6fce-4fa4-9031-d29cd49b210e)

### After Change
![after-change](https://github.com/soimy/msdf-bmfont-xml/assets/6070611/96a154e0-541f-4b77-9e57-cede74ea00b2)
