### PR TITLE
Look for arm64 binaries in _arm64 dirs

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,11 +53,11 @@ function generateBMFont (fontPath, opt, callback) {
     opt = {};
   }
 
-  const lookupKey = process.arch === "arm64" ?`${process.platform}_${process.arch}` : process.platform;
+  const platformKey = process.arch === "arm64" ?`${process.platform}_${process.arch}` : process.platform;
 
-  const binName = binaryLookup[lookupKey];
+  const binName = binaryLookup[platformKey];
 
-  assert.ok(binName, `No msdfgen binary for platform ${lookupKey}.`);
+  assert.ok(binName, `No msdfgen binary for platform ${platformKey}.`);
   assert.ok(fontPath, 'must specify a font path');
   assert.ok(typeof fontPath === 'string' || fontPath instanceof Buffer, 'font must be string path or Buffer');
   assert.ok(opt.filename || !(fontPath instanceof Buffer), 'must specify filename if font is a Buffer');
@@ -67,7 +67,7 @@ function generateBMFont (fontPath, opt, callback) {
 
   // Set fallback output path to font path
   let fontDir = typeof fontPath === 'string' ? path.dirname(fontPath) : '';
-  const binaryPath = path.join(__dirname, 'bin', process.platform, binName);
+  const binaryPath = path.join(__dirname, 'bin', platformKey, binName);
 
   // const reuse = (typeof opt.reuse === 'boolean' || typeof opt.reuse === 'undefined') ? {} : opt.reuse.opt;
   let reuse, cfg = {};


### PR DESCRIPTION
Relates to #89 and #90.

When I tried running the latest code on a Mac with arm64 architecture and without Rosetta installed, it failed because it was still trying to execute `bin/darwin/msdfgen.osx`. I’ve updated the `binaryPath` to fix this, which should fix both MacOS and Linux.

Also renamed the var from `lookupKey` to `platformKey` so it makes more sense to use it as part of `binaryPath`.