### PR TITLE
fix: change opentype parse method

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,10 +123,8 @@ function generateBMFont (fontPath, opt, callback, customLog) {
   if (fieldType !== 'msdf' && fieldType !== 'sdf' && fieldType !== 'psdf') {
     throw new TypeError('fieldType must be one of msdf, sdf, or psdf');
   }
-
-  const font = typeof fontPath === 'string'
-    ? opentype.loadSync(fontPath)
-    : opentype.parse(utils.bufferToArrayBuffer(fontPath));
+  const fontBuffer = typeof fontPath === 'string' ? fs.readFileSync(fontPath) : fontPath;
+  const font = opentype.parse(utils.bufferToArrayBuffer(fontBuffer));
 
   if (font.outlinesFormat !== 'truetype' && font.outlinesFormat !== 'cff') {
     throw new TypeError('must specify a truetype font (ttf, otf, woff)');


### PR DESCRIPTION
**Problem:**

There is problem with  **opentype.loadSync**

**Fix:**

Change **opentype.loadSync** to **fs.readFileSync(fontPath)**

<img width="556" height="19" alt="image" src="https://github.com/user-attachments/assets/90ff96cf-984a-4ed7-9f7d-9ea5bc6583d9" />
